### PR TITLE
fix: remove manual edge creation to prevent duplicate connections

### DIFF
--- a/src/lib/components/FlowEditor.svelte
+++ b/src/lib/components/FlowEditor.svelte
@@ -76,12 +76,6 @@
 			{nodeTypes}
 			fitView
 			class="flow-container"
-			onconnect={(connection) => addEdge({ 
-				source: connection.source, 
-				target: connection.target,
-				sourceHandle: connection.sourceHandle,
-				targetHandle: connection.targetHandle
-			})}
 		>
 			<Background />
 			<Controls />


### PR DESCRIPTION
SvelteFlow updates the edges array automatically when using bind:edges. I was also adding edges manually in onconnect, causing every edge to be created twice.